### PR TITLE
lowercase HOST variable to prevent gitea bug

### DIFF
--- a/workloads/gitea/deploy
+++ b/workloads/gitea/deploy
@@ -6,7 +6,7 @@ HERE=$(dirname "$(readlink --canonicalize "$BASH_SOURCE")")
 . "$ROOT/library/_trap"
 . "$HERE/_env"
 
-HOST=$(hostname):32100
+HOST=$(echo $(hostname) |tr '[:upper:]' '[:lower:]'):32100
 
 rm --force --recursive "$HERE/admin/tokens/"
 


### PR DESCRIPTION
Sometimes the user hostname can contain capitalized letters. Combined with xdg opening the gitea web page, this can lead to problems with the opened uri not being capitalized, like this:
![image](https://user-images.githubusercontent.com/62351083/225639040-7ecaac0d-6471-44d3-8d17-33214d766e02.png)
proposed solution: uri comprised of lowercase letters, achieved by switching the hostname variable to lowercase letters